### PR TITLE
Introduce annotation for changing bean discovery mode in synthetic archive

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/auto/ClassScanning.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/auto/ClassScanning.java
@@ -73,6 +73,7 @@ class ClassScanning {
         Set<Class<?>> foundClasses = new HashSet<>();
         Set<Type> excludedBeanTypes = new HashSet<>();
         Set<Class<?>> excludedBeanClasses = new HashSet<>();
+        boolean syntheticArchiveDiscoverySet = false;
 
         while (!classesToProcess.isEmpty()) {
 
@@ -197,6 +198,15 @@ class ClassScanning {
                     .flatMap(ann -> stream(ann.value()))
                     .distinct()
                     .forEach(excludedBeanClasses::add);
+
+            // discovery mode can only be set once; we use the first annotation we find
+            if (!syntheticArchiveDiscoverySet) {
+                Optional<SetBeanDiscoveryMode> annotation = AnnotationSupport.findAnnotation(currClass, SetBeanDiscoveryMode.class);
+                if (annotation.isPresent()) {
+                    syntheticArchiveDiscoverySet = true;
+                    weld.setBeanDiscoveryMode(annotation.get().value());
+                }
+            }
 
         }
 

--- a/junit5/src/main/java/org/jboss/weld/junit5/auto/SetBeanDiscoveryMode.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/auto/SetBeanDiscoveryMode.java
@@ -1,0 +1,26 @@
+package org.jboss.weld.junit5.auto;
+
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Sets discovery mode for Weld SE synthetic bean archive. Valid options are {@link BeanDiscoveryMode#ALL} and
+ * {@link BeanDiscoveryMode#ANNOTATED}.
+ * <p>
+ * Starting with Weld 5 (CDI 4), the default value is {@code ANNOTATED}. Applications can leverage this annotation to
+ * enforce same behavior as older Weld versions where synthetic archives used discovery mode {@code ALL}.
+ * <p>
+ * This annotation is equal to invocation of {@link org.jboss.weld.environment.se.Weld#setBeanDiscoveryMode(BeanDiscoveryMode)}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+public @interface SetBeanDiscoveryMode {
+
+    BeanDiscoveryMode value();
+}

--- a/junit5/src/main/java/org/jboss/weld/junit5/auto/WeldJunit5AutoExtension.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/auto/WeldJunit5AutoExtension.java
@@ -53,6 +53,7 @@ import java.util.stream.Collectors;
  * @see ExcludeBean
  * @see ExcludeBeanClasses
  * @see EnableAutoWeld
+ * @see SetBeanDiscoveryMode
  * @see WeldJunitEnricher
  */
 public class WeldJunit5AutoExtension extends WeldJunit5Extension {

--- a/junit5/src/test/java/org/jboss/weld/junit5/auto/SetDiscoveryModeAllTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/auto/SetDiscoveryModeAllTest.java
@@ -1,0 +1,31 @@
+package org.jboss.weld.junit5.auto;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.junit5.auto.discovery.WithBeanDefiningAnnotation;
+import org.jboss.weld.junit5.auto.discovery.WithoutBeanDefiningAnnotation;
+import org.junit.jupiter.api.Test;
+
+@EnableAutoWeld
+@AddPackages(value = WithBeanDefiningAnnotation.class, recursively = false)
+@SetBeanDiscoveryMode(BeanDiscoveryMode.ALL)
+public class SetDiscoveryModeAllTest {
+
+    @Inject
+    private WithBeanDefiningAnnotation standardBean;
+
+    @Inject
+    Instance<Object> instance;
+
+    @Test
+    void testDiscoveryModeWasChanged() {
+        // bean with bean defining annotation is normally resolvable
+        assertNotNull(standardBean);
+        // bean without bean defining annotation is discovered as well because we set discovery to ALL
+        assertTrue(instance.select(WithoutBeanDefiningAnnotation.class).isResolvable());
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/auto/discovery/WithBeanDefiningAnnotation.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/auto/discovery/WithBeanDefiningAnnotation.java
@@ -1,0 +1,7 @@
+package org.jboss.weld.junit5.auto.discovery;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class WithBeanDefiningAnnotation {
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/auto/discovery/WithoutBeanDefiningAnnotation.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/auto/discovery/WithoutBeanDefiningAnnotation.java
@@ -1,0 +1,5 @@
+package org.jboss.weld.junit5.auto.discovery;
+
+// intentionally doesn't have any bean defining annotation
+public class WithoutBeanDefiningAnnotation {
+}


### PR DESCRIPTION
Fixes #158 
Related JIRA - https://issues.redhat.com/browse/WELD-2766

We could also choose to drop the value on the annotation (always setting `all` as `none` is an error anyway). However, that would then make a mess of it in case there is a hierarchy of test classes with multiple declarations of this annotation.
Another option would be to add this as a param to an existing annotation such as `@EnableAutoWeld` but that one is optional in that you can use `@ExtendWith(WeldJunit5AutoExtension.class)` instead.