### PR TITLE
junit parameter resolver

### DIFF
--- a/junit5/README.md
+++ b/junit5/README.md
@@ -645,7 +645,7 @@ This section describes any additional configuration options this extension offer
 ### Explicit Parameter Injection
 
 As mentioned above, Weld is greedy when it comes to parameter injection.
-It will claim the ability to resolve any parameter which is known as a bean type inside the running CDI container.
+It will claim the ability to resolve any parameter which is known as a bean type inside the running CDI container except the ones built into JUnit itself.
 This is mainly for usability, as it would be annoying to constantly type additional annotations to mark which parameter should be injected and which should be left alone.
 
 However, we are aware that this might cause trouble if more extensions are competing for parameter resolution.

--- a/junit5/src/test/java/org/jboss/weld/junit5/compat/JunitParameterResolverAutoWeldTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/compat/JunitParameterResolverAutoWeldTest.java
@@ -1,0 +1,8 @@
+package org.jboss.weld.junit5.compat;
+
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+
+@EnableAutoWeld
+class JunitParameterResolverAutoWeldTest extends JunitParameterResolverReferenceTest {
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/compat/JunitParameterResolverReferenceTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/compat/JunitParameterResolverReferenceTest.java
@@ -1,0 +1,38 @@
+package org.jboss.weld.junit5.compat;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * This test runs without CDI in order to demonstrate that it works with plain JUnit.
+ */
+class JunitParameterResolverReferenceTest {
+
+    @Test
+    void testResolveTestInfo(TestInfo testInfo) {
+        Assertions.assertNotNull(testInfo);
+    }
+
+    @RepeatedTest(1)
+    void testResolveRepetitionInfo(RepetitionInfo repetitionInfo) {
+        Assertions.assertNotNull(repetitionInfo);
+    }
+
+    @Test
+    void testResolveTestReporter(TestReporter testReporter) {
+        Assertions.assertNotNull(testReporter);
+    }
+
+    @Test
+    void testResolveTempDir(@TempDir Path tempDir) {
+        Assertions.assertNotNull(tempDir);
+    }
+
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/compat/JunitParameterResolverWeldTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/compat/JunitParameterResolverWeldTest.java
@@ -1,0 +1,8 @@
+package org.jboss.weld.junit5.compat;
+
+import org.jboss.weld.junit5.EnableWeld;
+
+@EnableWeld
+class JunitParameterResolverWeldTest extends JunitParameterResolverReferenceTest {
+
+}


### PR DESCRIPTION
A test with a JUnit resolved `TestInfo` parameter fails upon just enabling weld-testing with `@EnableWeld` or `@EnableAutoWeld`:

```
    @Test
    void testResolveTestInfo(TestInfo testInfo) {
        Assertions.assertNotNull(testInfo);
    }
```
==>
org.junit.jupiter.api.extension.ParameterResolutionException: Weld has failed to resolve test parameter [org.junit.jupiter.api.TestInfo arg0]
Unsatisfied dependency has type org.junit.jupiter.api.TestInfo and qualifiers [].

see also https://junit.org/junit5/docs/current/user-guide/#writing-tests-dependency-injection