### PR TITLE
Clarify that WeldInitiator.from() and WeldInitiator.of() should use the same variable scope

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/WeldInitiator.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/WeldInitiator.java
@@ -70,8 +70,13 @@ public class WeldInitiator extends AbstractWeldInitiator {
 
     /**
      * The container is configured through a provided {@link Weld} instance.
+     * <p>
+     * Provided instance of {@link Weld} should be kept in the same scope as the resulting {@link WeldInitiator}.
+     * I.e. if {@link Weld} instance is kept in a static field, so should be the resulting {@link WeldInitiator}.
+     * Failing to uphold this can lead to repetitive configuration of the same {@link Weld} instance which in turn results in
+     * unexpected container setup/behavior.
      *
-     * @param weld
+     * @param weld instance of {@link Weld} used to create {@link WeldInitiator}
      * @return a new WeldInitiator instance
      */
     public static WeldInitiator of(Weld weld) {
@@ -120,8 +125,13 @@ public class WeldInitiator extends AbstractWeldInitiator {
 
     /**
      * Create a builder instance.
+     * <p>
+     * Provided instance of {@link Weld} should be kept in the same scope as the resulting {@link WeldInitiator}.
+     * I.e. if {@link Weld} instance is kept in a static field, so should be the resulting {@link WeldInitiator}.
+     * Failing to uphold this can lead to repetitive configuration of the same {@link Weld} instance which in turn results in
+     * unexpected container setup/behavior.
      *
-     * @param weld
+     * @param weld instance of {@link Weld} used as a basis for this {@link WeldInitiator.Builder}
      * @return a builder instance
      * @see #of(Weld)
      */


### PR DESCRIPTION
Fixes #167 

While we cannot enforce this, we should still mention it as it's not very clear to users.
While keeping partly configured `Weld` instance in a static field, having `WeldInitiator` in  non-static variable means that another layer of configuration is being applied to the same `Weld` instance for each test method in that given class.
This leads to some unexpected and hard-to-debug scenarios.