### PR TITLE
Do not greedily inject @ParameterizedTest; instead treat is as explicit param. injection

### DIFF
--- a/junit5/README.md
+++ b/junit5/README.md
@@ -89,6 +89,7 @@ This default behaviour includes:
 * Inject into method parameters of your test methods
   * If the type of the parameter matches a known and resolvable bean
   * By default, Weld is greedy and will try to resolve all parameters which are known as bean types in the container
+    * An exception to this rule is `@ParameterizedTest` where Weld requires explicitly stating CDI qualifiers for each method parameter which should be injected
   * If this behaviour should be different, refer to [additional configuration section](#explicit-parameter-injection)
 * Shut down the container after test is done
 

--- a/junit5/pom.xml
+++ b/junit5/pom.xml
@@ -31,6 +31,10 @@
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-engine</artifactId>
       </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-params</artifactId>
+      </dependency>
 
       <!-- Test dependencies -->
       <dependency>

--- a/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * JUnit 5 extension allowing to bootstrap Weld SE container for each @Test method (or once per test class
@@ -192,7 +193,10 @@ public class WeldJunit5Extension implements AfterAllCallback, BeforeAllCallback,
         List<Annotation> qualifiers = resolveQualifiers(parameterContext,
                 getContainerFromStore(extensionContext).getBeanManager());
         // if we require explicit parameter injection (via global settings or annotation) and there are no qualifiers we don't resolve it
-        if ((getExplicitInjectionInfoFromStore(extensionContext) || (methodRequiresExplicitParamInjection(parameterContext)))
+        // if the method is annotated @ParameterizedTest, we treat it as explicit param injection and require qualifiers
+        if ((getExplicitInjectionInfoFromStore(extensionContext)
+                || methodRequiresExplicitParamInjection(parameterContext)
+                || methodIsParameterizedTest(parameterContext))
                 && qualifiers.isEmpty()) {
             return false;
         } else {
@@ -251,6 +255,10 @@ public class WeldJunit5Extension implements AfterAllCallback, BeforeAllCallback,
             return ann.value();
         }
         return false;
+    }
+
+    private boolean methodIsParameterizedTest(ParameterContext pc) {
+        return pc.getDeclaringExecutable().getAnnotation(ParameterizedTest.class) != null ? true : false;
     }
 
     private TestInstance.Lifecycle determineTestLifecycle(ExtensionContext ec) {

--- a/junit5/src/test/java/org/jboss/weld/junit5/explicitInjection/parameterizedTest/Foo.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/explicitInjection/parameterizedTest/Foo.java
@@ -1,0 +1,15 @@
+package org.jboss.weld.junit5.explicitInjection.parameterizedTest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class Foo {
+
+    @Produces
+    String s = "fooString";
+
+    String ping() {
+        return Foo.class.getSimpleName();
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/explicitInjection/parameterizedTest/ParameterizedTestExplicitInjectionTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/explicitInjection/parameterizedTest/ParameterizedTestExplicitInjectionTest.java
@@ -1,0 +1,46 @@
+package org.jboss.weld.junit5.explicitInjection.parameterizedTest;
+
+import java.util.Set;
+
+import jakarta.enterprise.inject.Default;
+
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ExtendWith(WeldJunit5Extension.class)
+public class ParameterizedTestExplicitInjectionTest {
+
+    public static final Set<String> strings = Set.of("one", "two", "three");
+
+    @ParameterizedTest
+    @ValueSource(strings = { "one", "two", "three" })
+    public void noWeldInjection(String param) {
+        // String param is not resolved by Weld
+        Assertions.assertTrue(strings.contains(param));
+    }
+
+    // NOTE: swapping parameters in the below tests leads to a failure! Parameterized test attempts to claim the first
+    // parameter as its own and cast to given type; there is nothing we can do about that
+    @ParameterizedTest
+    @ValueSource(strings = { "one", "two", "three" })
+    public void parameterizedTestWithWeldInjection(String param, @Default Foo foo) {
+        // String param is not resolved by Weld
+        Assertions.assertTrue(strings.contains(param));
+        // Foo has explicit qualifier and Weld therefore still tried to resolve it
+        Assertions.assertNotNull(foo);
+        Assertions.assertEquals(Foo.class.getSimpleName(), foo.ping());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "one", "two", "three" })
+    public void parameterizedTestWithTwoStringParams(String param, @Default String anotherString) {
+        // String param is not resolved by Weld
+        Assertions.assertTrue(strings.contains(param));
+        // Foo has explicit qualifier and Weld therefore still tried to resolve it
+        Assertions.assertNotNull(anotherString);
+        Assertions.assertEquals("fooString", anotherString);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <version>${version.junit.jupiter}</version>
          </dependency>
 
+          <dependency>
+              <groupId>org.junit.jupiter</groupId>
+              <artifactId>junit-jupiter-params</artifactId>
+              <version>${version.junit.jupiter}</version>
+          </dependency>
+
          <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>


### PR DESCRIPTION
Fixes #169 


This is one of the options that I thought of as a solution - we will now avoid injecting into such test unless there is an explicit CDI qualifier at any given parameter.
Note that junit is very simple in its approach and always considers the very first arg. to be the parameterized one (or first `n` params if you have more) and there is nothing we can do about that. This means that users can still try to have first param resolved by Weld (by adding qualifier) and have a conflict of multiple extensions competing for that given parameter.

The other option I had in mind was simply not injecting into `@ParameterizedTest` at all unless annotated with explicit param injection. I don't mind either, I just thought the one I proposed here is a tad bit user friendlier.