### PR TITLE
auto-detect @Inject method parameter types

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/auto/ClassScanning.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/auto/ClassScanning.java
@@ -101,7 +101,7 @@ class ClassScanning {
                     .forEach(cls -> addClassesToProcess(classesToProcess, cls));
 
             AnnotationSupport.findAnnotatedMethods(currClass, Inject.class, HierarchyTraversalMode.BOTTOM_UP).stream()
-                    .map(Method::getReturnType)
+                    .flatMap(method -> getExecutableParameterTypes(method, explicitInjection).stream())
                     .forEach(cls -> addClassesToProcess(classesToProcess, cls));
 
             findFirstAnnotatedConstructor(currClass, Inject.class)

--- a/junit5/src/test/java/org/jboss/weld/junit5/auto/InjectMethodParamTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/auto/InjectMethodParamTest.java
@@ -1,0 +1,29 @@
+package org.jboss.weld.junit5.auto;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+
+@EnableAutoWeld
+class InjectMethodParamTest {
+
+    @Dependent
+    static class Foo {
+    }
+
+    private Foo foo;
+
+    @Inject
+    private void setFoo(Foo foo) {
+        this.foo = foo;
+    }
+
+    @Test
+    void testInjectMethodParametersAreAddedToContainerWithNoConfiguration() {
+        assertNotNull(foo);
+    }
+
+}


### PR DESCRIPTION
https://github.com/weld/weld-testing/blob/b2c1c6f08d010947cccd1e552fc1d54cbbb315ec/junit5/README.md?plain=1#L5 says that the extension will

> inject into all your `@Inject` fields and *method parameters* in the given test instance

However, it looks like only the field type is detected and added to the container and not the method parameter type.

Also,

```
    private Foo foo;

    @Inject
    private void setFoo(Foo foo) {
        this.foo = foo;
    }
```

should essentially be short for

```
    @Inject
    private Foo foo;
```

But only the field injection works as of now as far as I figure