### PR TITLE
Update version.weld to 3.1.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <!-- Versions -->
       <version.junit4>4.13.1</version.junit4>
       <version.junit.jupiter>5.4.1</version.junit.jupiter>
-      <version.weld>3.1.6.Final</version.weld>
+      <version.weld>3.1.9.Final</version.weld>
       <version.mockito>2.25.1</version.mockito>
       <version.jboss-ejb-api>1.0.0.Final</version.jboss-ejb-api>
       <version.hibernate-jpa-api>1.0.0.Final</version.hibernate-jpa-api>


### PR DESCRIPTION
The latest weld version of the version 3 branch contains fixes regarding JDK 17 (for example [WELD-2671](https://issues.jboss.org/browse/WELD-2671)). As the version 2 branch of weld-testing does not seem to regularly receive dependency updates, this currently forces us to add weld-se-core as an explicit dependency which we would like to avoid. We currently can't update beyond version 2 of weld-testing as the application server version we're using does not support CDI > 2.