### PR TITLE
Clean up any autocloseable sources from Store to prevent re-attempting Weld shut down on JUnit 5.13+

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/ExtensionContextUtils.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/ExtensionContextUtils.java
@@ -106,6 +106,16 @@ public class ExtensionContextUtils {
     }
 
     /**
+     * Removes {@link WeldContainer} from {@link ExtensionContext.Store}.
+     * <p>
+     * This needs to be invoked before we complete shutdown otherwise JUnit (5.13+) attempts to close all autocloseable
+     * resources which results in it trying to shut down Weld SE container that is no longer running.
+     */
+    public static void removeContainerFromStore(ExtensionContext context) {
+        getTestStore(context).remove(CONTAINER);
+    }
+
+    /**
      * Store {@link WeldContainer} to {@link ExtensionContext.Store}
      */
     public static void setContainerToStore(ExtensionContext context, WeldContainer container) {

--- a/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
@@ -20,6 +20,7 @@ import static org.jboss.weld.junit5.ExtensionContextUtils.getContainerFromStore;
 import static org.jboss.weld.junit5.ExtensionContextUtils.getEnrichersFromStore;
 import static org.jboss.weld.junit5.ExtensionContextUtils.getExplicitInjectionInfoFromStore;
 import static org.jboss.weld.junit5.ExtensionContextUtils.getInitiatorFromStore;
+import static org.jboss.weld.junit5.ExtensionContextUtils.removeContainerFromStore;
 import static org.jboss.weld.junit5.ExtensionContextUtils.setContainerToStore;
 import static org.jboss.weld.junit5.ExtensionContextUtils.setEnrichersToStore;
 import static org.jboss.weld.junit5.ExtensionContextUtils.setExplicitInjectionInfoToStore;
@@ -144,6 +145,9 @@ public class WeldJunit5Extension implements AfterAllCallback, BeforeAllCallback,
         if (determineTestLifecycle(context).equals(PER_METHOD)) {
             WeldInitiator initiator = getInitiatorFromStore(context);
             if (initiator != null) {
+                // Clean up all auto-closeable sources in the Store
+                removeContainerFromStore(context);
+                // Perform Weld container shut down
                 initiator.shutdownWeld();
             }
         }
@@ -154,6 +158,9 @@ public class WeldJunit5Extension implements AfterAllCallback, BeforeAllCallback,
         if (determineTestLifecycle(context).equals(PER_CLASS)) {
             WeldInitiator initiator = getInitiatorFromStore(context);
             if (initiator != null) {
+                // Clean up all auto-closeable sources in the Store
+                removeContainerFromStore(context);
+                // Perform Weld container shut down
                 initiator.shutdownWeld();
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <version.spock>2.4-M6-groovy-4.0</version.spock>
       <version.junit.platform>1.12.2</version.junit.platform>
       <version.groovy>3.0.24</version.groovy>
-      <version.weld>6.0.1.Final</version.weld>
+      <version.weld>6.0.3.Final</version.weld>
       <version.mockito>5.17.0</version.mockito>
       <version.jakarta.ejb.api>4.0.1</version.jakarta.ejb.api>
       <version.jakarta.inject>2.0.1</version.jakarta.inject>


### PR DESCRIPTION
Fixes #264 

Also updates Weld 6 to latest release.
Weld JUnit version is kept as-is so that we do not reference non-final release.