### PR TITLE
Correct test instance lifecycle detection

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/WeldJunit5Extension.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
@@ -269,12 +270,12 @@ public class WeldJunit5Extension implements AfterAllCallback, BeforeAllCallback,
     }
 
     private TestInstance.Lifecycle determineTestLifecycle(ExtensionContext ec) {
-        // check the test for org.junit.jupiter.api.TestInstance annotation
-        TestInstance annotation = ec.getRequiredTestClass().getAnnotation(TestInstance.class);
-        if (annotation != null) {
-            return annotation.value();
+        Optional<TestInstance.Lifecycle> testInstanceLifecycle = ec.getTestInstanceLifecycle();
+        if (testInstanceLifecycle.isEmpty()) {
+            // this should never happen, but if so, we assume default
+            return PER_METHOD;
         } else {
-            return TestInstance.Lifecycle.PER_METHOD;
+            return testInstanceLifecycle.get();
         }
     }
 

--- a/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PerClassLifecycleChildTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PerClassLifecycleChildTest.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.junit5.testLifecycle;
+
+// all configuration is inherited, so are test methods
+// we should recognize this class as having per-class lifecycle and bootstrap Weld accordingly
+public class PerClassLifecycleChildTest extends PerClassLifecycleTest {
+
+    static String childContainerId = null;
+
+    @Override
+    String getContainerId() {
+        return childContainerId;
+    }
+
+    @Override
+    void setContainerId(String id) {
+        childContainerId = id;
+    }
+}

--- a/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PerClassLifecycleTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/testLifecycle/PerClassLifecycleTest.java
@@ -41,23 +41,31 @@ public class PerClassLifecycleTest {
     public WeldInitiator initiator = WeldInitiator.of(new Weld(String.valueOf(System.nanoTime()))
             .disableDiscovery().addBeanClass(PlainBean.class));
 
-    String containerId = null;
+    static String containerId = null;
+
+    String getContainerId() {
+        return containerId;
+    }
+
+    void setContainerId(String id) {
+        containerId = id;
+    }
 
     @Test
     public void first() {
-        if (containerId == null) {
-            containerId = WeldContainer.current().getId();
+        if (getContainerId() == null) {
+            setContainerId(WeldContainer.current().getId());
         } else {
-            Assertions.assertEquals(containerId, WeldContainer.current().getId());
+            Assertions.assertEquals(getContainerId(), WeldContainer.current().getId());
         }
     }
 
     @Test
     public void second() {
-        if (containerId == null) {
-            containerId = WeldContainer.current().getId();
+        if (getContainerId() == null) {
+            setContainerId(WeldContainer.current().getId());
         } else {
-            Assertions.assertEquals(containerId, WeldContainer.current().getId());
+            Assertions.assertEquals(getContainerId(), WeldContainer.current().getId());
         }
     }
 }


### PR DESCRIPTION
Fixes #288 

The test tweaks here is just to expand on an existing one and correct its assertions but it *does not* cover the case for which I added the fix.

The fix itself is meant to cover a case of hierarchies (which we "accidentally" supported even before) and using a global configuration `junit.jupiter.testinstance.lifecycle.default = per_class`. The latter means that for instance nested tests should be interpreted as having per-class lifecycle despite not having annotation for it which we didn't take into account previously. However, we cannot automatically test that.

@nlisker care to give this a spin with your use case?
Building the projects is as simple as `mvn clean install` in its root and then use the `SNAPSHOT` as your dependency.