### PR TITLE
Minimal changes to make Weld Junit extension compatible with JUnit 6

### DIFF
--- a/junit5/src/main/java/org/jboss/weld/junit5/auto/ClassScanning.java
+++ b/junit5/src/main/java/org/jboss/weld/junit5/auto/ClassScanning.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
-import org.junit.platform.commons.util.CollectionUtils;
 import org.junit.platform.commons.util.Preconditions;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -315,13 +314,13 @@ class ClassScanning {
     private static List<Field> findAnnotatedDeclaredFields(Class<?> clazz, Class<? extends Annotation> annotationType) {
         return getDeclaredFields(clazz).stream()
                 .filter((field) -> isAnnotated(field, annotationType))
-                .collect(CollectionUtils.toUnmodifiableList());
+                .collect(Collectors.toUnmodifiableList());
     }
 
     private static List<Method> findAnnotatedDeclaredMethods(Class<?> clazz, Class<? extends Annotation> annotationType) {
         return getDeclaredMethods(clazz).stream()
                 .filter((field) -> isAnnotated(field, annotationType))
-                .collect(CollectionUtils.toUnmodifiableList());
+                .collect(Collectors.toUnmodifiableList());
     }
 
     private static List<Constructor<?>> getDeclaredConstructors(Class<?> clazz) {

--- a/junit5/src/test/java/org/jboss/weld/junit5/basic/DisabledMethodsTest.java
+++ b/junit5/src/test/java/org/jboss/weld/junit5/basic/DisabledMethodsTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.parallel.Isolated;
  */
 @Isolated
 @ExtendWith(WeldJunit5Extension.class)
-@TestMethodOrder(value = MethodOrderer.Alphanumeric.class) // enforces ordering of methods, required!
+@TestMethodOrder(value = MethodOrderer.MethodName.class) // enforces ordering of methods, required!
 public class DisabledMethodsTest {
 
     @WeldSetup


### PR DESCRIPTION
Fixes #300

The `ClassScanning` class uses an internal JUnit API which has no guarantees to stay that away and was changed in version 6 so we steer away from it.
The test change is due to deprecated annotation being removed and replaced by another with the same function.