### PR TITLE
Rename default branch references from master to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 20
-  target-branch: master
+  target-branch: main
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -17,7 +17,7 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 20
-  target-branch: master
+  target-branch: main
 - package-ecosystem: maven
   directory: "/"
   schedule:

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -2,7 +2,7 @@ name: Weld Testing CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-weld-junit:
@@ -43,7 +43,7 @@ jobs:
         path: ~/.m2/repository
         # Caching is an automated pre/post action that installs the cache if the key exists and exports the cache
         # after the job is done. In this case we refresh the cache monthly (by changing key) to avoid unlimited growth.
-        key: q2maven-master-${{ steps.get-date.outputs.date }}
+        key: q2maven-main-${{ steps.get-date.outputs.date }}
     - name: Build with Maven
       run: WELD_JUNIT_DEBUG=spotbugs mvn clean install -Dno-format -Dspotbugs.failOnError=true
     - name: Delete Local Artifacts From Cache


### PR DESCRIPTION
Just trivial changes to configs that referenced master branch.