### PR TITLE
Add GitHub Release step and update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,24 +3,31 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 20
+    interval: weekly
+  open-pull-requests-limit: 15
   target-branch: main
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 20
+    interval: weekly
+  open-pull-requests-limit: 15
   target-branch: "5.0"
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 20
+    interval: weekly
+  open-pull-requests-limit: 15
   target-branch: main
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 20
+    interval: weekly
+  open-pull-requests-limit: 15
   target-branch: "5.0"
+  ignore:
+    - dependency-name: "jakarta.ejb:jakarta.ejb-api"
+      versions: ["[4.1,)"]
+    - dependency-name: "jakarta.persistence:jakarta.persistence-api"
+      versions: ["[4.0,)"]
+    - dependency-name: "org.jboss.weld:weld-core-impl"
+      versions: ["[7.0,)"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,11 @@ jobs:
       uses: actions/checkout@v6
       with:
         token: ${{secrets.RELEASE_TOKEN}}
+        # Full history needed for git describe in the GitHub Release step
+        fetch-depth: 0
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v5.2.0
+      uses: actions/setup-java@v5
       with:
         distribution: temurin
         java-version: 17
@@ -55,3 +57,19 @@ jobs:
         mvn -B release:perform -Drelease
         git push
         git push --tags
+
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{secrets.RELEASE_TOKEN}}
+      run: |
+        TAG=${{steps.metadata.outputs.current-version}}
+        PREV_TAG=$(git describe --abbrev=0 --tags "${TAG}^")
+        PRERELEASE_FLAG=""
+        if echo "${TAG}" | grep -qE 'Alpha|Beta|CR'; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+        gh release create "${TAG}" \
+          --generate-notes \
+          --notes-start-tag "${PREV_TAG}" \
+          --title "Weld Testing ${TAG}" \
+          ${PRERELEASE_FLAG}


### PR DESCRIPTION
Add GitHub Release creation during releases and update Dependabot to weekly intervals with Jakarta EE 11 version pins for the 5.0 branch.