### PR TITLE
Revert unnecessary CI branch filter change

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -2,7 +2,7 @@ name: Weld Testing CI
 
 on:
   pull_request:
-    branches: [ main, 5.0 ]
+    branches: [ main ]
 
 jobs:
   build-weld-junit:


### PR DESCRIPTION
This was my error, should have gone to 5.0 branch :facepalm: 