### PR TITLE
Clear explicit param injection property instead of blanking it

### DIFF
--- a/junit-jupiter/src/test/java/org/jboss/weld/junit/jupiter/explicitInjection/ExplicitParameterInjectionViaPropertyTest.java
+++ b/junit-jupiter/src/test/java/org/jboss/weld/junit/jupiter/explicitInjection/ExplicitParameterInjectionViaPropertyTest.java
@@ -56,6 +56,6 @@ public class ExplicitParameterInjectionViaPropertyTest {
 
     @AfterAll
     public static void cleanUp() {
-        System.setProperty(WeldJunit5Extension.GLOBAL_EXPLICIT_PARAM_INJECTION, "");
+        System.clearProperty(WeldJunit5Extension.GLOBAL_EXPLICIT_PARAM_INJECTION);
     }
 }


### PR DESCRIPTION
Other similar tests use this already; seems this one was forgotten.